### PR TITLE
Make size report in bytes instead of number of entries when weighted.

### DIFF
--- a/src/main/java/com/metamx/cache/CaffeineCache.java
+++ b/src/main/java/com/metamx/cache/CaffeineCache.java
@@ -36,6 +36,7 @@ import net.jpountz.lz4.LZ4FastDecompressor;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -118,11 +119,15 @@ public class CaffeineCache implements io.druid.client.cache.Cache
   public io.druid.client.cache.CacheStats getStats()
   {
     final com.github.benmanes.caffeine.cache.stats.CacheStats stats = cache.stats();
+    final long size = cache
+        .policy().eviction()
+        .map(eviction -> eviction.isWeighted() ? eviction.weightedSize() : OptionalLong.empty())
+        .orElse(OptionalLong.empty()).orElse(-1);
     return new io.druid.client.cache.CacheStats(
         stats.hitCount(),
         stats.missCount(),
-        stats.loadSuccessCount() - stats.evictionCount(),
         cache.estimatedSize(),
+        size,
         stats.evictionCount(),
         0,
         stats.loadFailureCount()

--- a/src/test/java/com/metamx/cache/CaffeineCacheTest.java
+++ b/src/test/java/com/metamx/cache/CaffeineCacheTest.java
@@ -226,6 +226,118 @@ public class CaffeineCacheTest
     Assert.assertArrayEquals(val2, cache.get(key2));
   }
 
+  @Test
+  public void testSizeCalculation()
+  {
+    final CaffeineCacheConfig config = new CaffeineCacheConfig()
+    {
+      @Override
+      public long getMaxSize()
+      {
+        return 40;
+      }
+    };
+    final Random random = new Random(843671346794319L);
+    final byte[] val1 = new byte[14], val2 = new byte[14];
+    final byte[] s1 = new byte[]{0x01}, s2 = new byte[]{0x02};
+    random.nextBytes(val1);
+    random.nextBytes(val2);
+    final Cache.NamedKey key1 = new Cache.NamedKey("the", s1);
+    final Cache.NamedKey key2 = new Cache.NamedKey("the", s2);
+    final Cache cache = CaffeineCache.create(config, Runnable::run);
+
+    CacheStats stats = cache.getStats();
+    Assert.assertEquals(0L, stats.getNumEntries());
+    Assert.assertEquals(0L, stats.getSizeInBytes());
+
+    cache.put(key1, val1);
+
+    stats = cache.getStats();
+    Assert.assertEquals(1L, stats.getNumEntries());
+    Assert.assertEquals(34L, stats.getSizeInBytes());
+
+    cache.put(key2, val2);
+
+    stats = cache.getStats();
+    Assert.assertEquals(1L, stats.getNumEntries());
+    Assert.assertEquals(34L, stats.getSizeInBytes());
+  }
+
+
+  @Test
+  public void testSizeCalculationMore()
+  {
+    final CaffeineCacheConfig config = new CaffeineCacheConfig()
+    {
+      @Override
+      public long getMaxSize()
+      {
+        return 400;
+      }
+    };
+    final Random random = new Random(843671346794319L);
+    final byte[] val1 = new byte[14], val2 = new byte[14];
+    final byte[] s1 = new byte[]{0x01}, s2 = new byte[]{0x02};
+    random.nextBytes(val1);
+    random.nextBytes(val2);
+    final Cache.NamedKey key1 = new Cache.NamedKey("the", s1);
+    final Cache.NamedKey key2 = new Cache.NamedKey("the", s2);
+    final Cache cache = CaffeineCache.create(config, Runnable::run);
+
+    CacheStats stats = cache.getStats();
+    Assert.assertEquals(0L, stats.getNumEntries());
+    Assert.assertEquals(0L, stats.getSizeInBytes());
+
+    cache.put(key1, val1);
+
+    stats = cache.getStats();
+    Assert.assertEquals(1L, stats.getNumEntries());
+    Assert.assertEquals(34L, stats.getSizeInBytes());
+
+    cache.put(key2, val2);
+
+    stats = cache.getStats();
+    Assert.assertEquals(2L, stats.getNumEntries());
+    Assert.assertEquals(68L, stats.getSizeInBytes());
+  }
+
+  @Test
+  public void testSizeCalculationNoWeight()
+  {
+    final CaffeineCacheConfig config = new CaffeineCacheConfig()
+    {
+      @Override
+      public long getMaxSize()
+      {
+        return -1;
+      }
+    };
+    final Random random = new Random(843671346794319L);
+    final byte[] val1 = new byte[14], val2 = new byte[14];
+    final byte[] s1 = new byte[]{0x01}, s2 = new byte[]{0x02};
+    random.nextBytes(val1);
+    random.nextBytes(val2);
+    final Cache.NamedKey key1 = new Cache.NamedKey("the", s1);
+    final Cache.NamedKey key2 = new Cache.NamedKey("the", s2);
+    final Cache cache = CaffeineCache.create(config, Runnable::run);
+
+    CacheStats stats = cache.getStats();
+    Assert.assertEquals(0L, stats.getNumEntries());
+    Assert.assertEquals(-1L, stats.getSizeInBytes());
+
+    cache.put(key1, val1);
+
+    stats = cache.getStats();
+    Assert.assertEquals(1L, stats.getNumEntries());
+    Assert.assertEquals(-1L, stats.getSizeInBytes());
+
+    cache.put(key2, val2);
+
+    stats = cache.getStats();
+    Assert.assertEquals(2L, stats.getNumEntries());
+    Assert.assertEquals(-1L, stats.getSizeInBytes());
+  }
+
   public int get(Cache cache, Cache.NamedKey key)
   {
     return Ints.fromByteArray(cache.get(key));


### PR DESCRIPTION
Currently size is simply reported in number of entries, this makes the size report as the weight size, if a maximum size is specified.
