### PR TITLE
Add weight eviction stats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.2.6</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>net.jpountz.lz4</groupId>

--- a/src/main/java/com/metamx/cache/CaffeineCache.java
+++ b/src/main/java/com/metamx/cache/CaffeineCache.java
@@ -156,8 +156,8 @@ public class CaffeineCache implements io.druid.client.cache.Cache
     emitter.emit(builder.build("query/cache/caffeine/total/requests", newStats.requestCount()));
     emitter.emit(builder.build("query/cache/caffeine/delta/loadTime", deltaStats.totalLoadTime()));
     emitter.emit(builder.build("query/cache/caffeine/total/loadTime", newStats.totalLoadTime()));
-    emitter.emit(builder.build("query/cache/caffeine/delta/evictionWeight", deltaStats.evictionWeight()));
-    emitter.emit(builder.build("query/cache/caffeine/total/evictionWeight", newStats.evictionWeight()));
+    emitter.emit(builder.build("query/cache/caffeine/delta/evictionBytes", deltaStats.evictionWeight()));
+    emitter.emit(builder.build("query/cache/caffeine/total/evictionBytes", newStats.evictionWeight()));
     if (!priorStats.compareAndSet(oldStats, newStats)) {
       // ISE for stack trace
       log.warn(

--- a/src/main/java/com/metamx/cache/CaffeineCache.java
+++ b/src/main/java/com/metamx/cache/CaffeineCache.java
@@ -156,6 +156,8 @@ public class CaffeineCache implements io.druid.client.cache.Cache
     emitter.emit(builder.build("query/cache/caffeine/total/requests", newStats.requestCount()));
     emitter.emit(builder.build("query/cache/caffeine/delta/loadTime", deltaStats.totalLoadTime()));
     emitter.emit(builder.build("query/cache/caffeine/total/loadTime", newStats.totalLoadTime()));
+    emitter.emit(builder.build("query/cache/caffeine/delta/evictionWeight", deltaStats.evictionWeight()));
+    emitter.emit(builder.build("query/cache/caffeine/total/evictionWeight", newStats.evictionWeight()));
     if (!priorStats.compareAndSet(oldStats, newStats)) {
       // ISE for stack trace
       log.warn(
@@ -163,6 +165,11 @@ public class CaffeineCache implements io.druid.client.cache.Cache
           "Multiple monitors on the same cache causing race conditions and unreliable stats reporting"
       );
     }
+  }
+
+  Cache<NamedKey, byte[]> getCache()
+  {
+    return cache;
   }
 
   private final LZ4Factory factory = LZ4Factory.fastestInstance();

--- a/src/test/java/com/metamx/cache/CaffeineCacheTest.java
+++ b/src/test/java/com/metamx/cache/CaffeineCacheTest.java
@@ -192,7 +192,7 @@ public class CaffeineCacheTest
   }
 
   @Test
-  public void testSizeEviction()
+  public void testSizeEviction() throws InterruptedException
   {
     final CaffeineCacheConfig config = new CaffeineCacheConfig()
     {
@@ -209,7 +209,7 @@ public class CaffeineCacheTest
     random.nextBytes(val2);
     final Cache.NamedKey key1 = new Cache.NamedKey("the", s1);
     final Cache.NamedKey key2 = new Cache.NamedKey("the", s2);
-    final Cache cache = CaffeineCache.create(config, Runnable::run);
+    final CaffeineCache cache = CaffeineCache.create(config, Runnable::run);
 
     Assert.assertNull(cache.get(key1));
     Assert.assertNull(cache.get(key2));
@@ -218,12 +218,15 @@ public class CaffeineCacheTest
     Assert.assertArrayEquals(val1, cache.get(key1));
     Assert.assertNull(cache.get(key2));
 
+    Assert.assertEquals(0, cache.getCache().stats().evictionWeight());
+
     Assert.assertArrayEquals(val1, cache.get(key1));
     Assert.assertNull(cache.get(key2));
 
     cache.put(key2, val2);
     Assert.assertNull(cache.get(key1));
     Assert.assertArrayEquals(val2, cache.get(key2));
+    Assert.assertEquals(34, cache.getCache().stats().evictionWeight());
   }
 
   @Test


### PR DESCRIPTION
Adds a metric to determine the eviction rate. This gives us the cache throughput.
